### PR TITLE
Add missing functions to libelf.def

### DIFF
--- a/VC/libelf.def
+++ b/VC/libelf.def
@@ -79,4 +79,7 @@ EXPORTS
 	elf_getphnum
 	elf_getshnum
 	elf_getshstrndx
+	elf_getphdrnum
+	elf_getshdrnum
+	elf_getshdrstrndx
 	elfx_update_shstrndx

--- a/lib/libelf.def
+++ b/lib/libelf.def
@@ -79,5 +79,7 @@ EXPORTS
 	elf_getphnum
 	elf_getshnum
 	elf_getshstrndx
+	elf_getphdrnum
+	elf_getshdrnum
 	elf_getshdrstrndx
 	elfx_update_shstrndx

--- a/lib/libelf.def
+++ b/lib/libelf.def
@@ -79,4 +79,5 @@ EXPORTS
 	elf_getphnum
 	elf_getshnum
 	elf_getshstrndx
+	elf_getshdrstrndx
 	elfx_update_shstrndx


### PR DESCRIPTION
Hi

File libelf.def contains names of libraries exported for LibELF build by MS Visual Studio.
Unfortunately, there are no definitions of replacement functions for ELF extensions. I added them in these commits.

P. S. I noticed that WolfgangSt was active about 8 years ago. Nevertheless, I create pull request to provide solution for people who faced the same problem as me.